### PR TITLE
Resolving circular dependency

### DIFF
--- a/pysofaconventions/SOFAAttributes.py
+++ b/pysofaconventions/SOFAAttributes.py
@@ -165,6 +165,7 @@ class SOFAAttributes:
             cls.defaultAttributeValues[
                 cls.AttributeTypes.SOFAConventionsVersion
                 ] = SOFASimpleFreeFieldHRIR.getConventionVersion()
+            cls.davInitialized = True
 
         attr = cls.attributeTypesDict[attributeName]
         if cls.hasDefaultValueAttributes[attr]:

--- a/pysofaconventions/SOFAAttributes.py
+++ b/pysofaconventions/SOFAAttributes.py
@@ -160,6 +160,12 @@ class SOFAAttributes:
         :param attributeName:   he attribute name
         :return:                the default attribute value, or empty string if not found
         """
+        if not cls.davInitialized:
+            from .SOFAConventions import SOFASimpleFreeFieldHRIR
+            cls.defaultAttributeValues[
+                cls.AttributeTypes.SOFAConventionsVersion
+                ] = SOFASimpleFreeFieldHRIR.getConventionVersion()
+
         attr = cls.attributeTypesDict[attributeName]
         if cls.hasDefaultValueAttributes[attr]:
             return cls.defaultAttributeValues[attr]
@@ -269,6 +275,7 @@ class SOFAAttributes:
         AttributeTypes.EmitterDescription:      False,
     }
 
+    davInitialized = False
     defaultAttributeValues = {
         AttributeTypes.Conventions: 'SOFA',
         AttributeTypes.Version: SOFAAPI.getSpecificationsVersion(),

--- a/pysofaconventions/SOFAAttributes.py
+++ b/pysofaconventions/SOFAAttributes.py
@@ -281,7 +281,8 @@ class SOFAAttributes:
         AttributeTypes.Version: SOFAAPI.getSpecificationsVersion(),
         AttributeTypes.DataType: 'FIR',
         AttributeTypes.SOFAConventions: 'SimpleFreeFieldHRIR',
-        # TODO: importing SimpleFreeFieldHRIR causes multiple circular dependency errors to happen
+        # Importing SimpleFreeFieldHRIR causes multiple circular dependency errors to happen
+        # Import and assignment moved inside "getDefaultAttributeValue"
         # AttributeTypes.SOFAConventionsVersion: 'SimpleFreeFieldHRIR::GetConventionVersion()',
         AttributeTypes.SOFAConventionsVersion: '',
         AttributeTypes.APIName: SOFAAPI.getAPIName(),

--- a/tests/test_SOFAAttributes.py
+++ b/tests/test_SOFAAttributes.py
@@ -162,7 +162,7 @@ def test_getDefaultAttributeValue():
     assert SOFAAttributes.getDefaultAttributeValue('SOFAConventions')           \
            == 'SimpleFreeFieldHRIR'
     assert SOFAAttributes.getDefaultAttributeValue('SOFAConventionsVersion')    \
-           == ''
+           == SOFASimpleFreeFieldHRIR.getConventionVersion()
     assert SOFAAttributes.getDefaultAttributeValue('APIName')                   \
            == SOFAAPI.getAPIName()
     assert SOFAAttributes.getDefaultAttributeValue('APIVersion')                \


### PR DESCRIPTION
In looking at resolving circular dependencies, I found the "pythonic" way of doing this was to move imports inside of functions/methods where possible. Since the default values are only needed in the "getDefaultAttributeValue" function, this seemed the right place to place the import. Rather than import every time the function is called, I added one variable to indicate if the default value had already been set.